### PR TITLE
[🔀 Reward] 뱃지, 회원-뱃지 기능 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,6 @@ out/
 /node_modules/
 package-lock.json
 .DS_Store
+
+### Secret ###
+src/main/resources/

--- a/build.gradle
+++ b/build.gradle
@@ -29,9 +29,22 @@ ext {
 }
 
 dependencies {
-    // spring cloud starters
+    // spring boot starters
+    implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-actuator'
+
+    // spring cloud
     implementation 'org.springframework.cloud:spring-cloud-starter-config'
     implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
+
+    // Databases / JPA
+    implementation 'org.springframework.boot:spring-boot-starter-data-mongodb'
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    runtimeOnly 'com.mysql:mysql-connector-j'
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+
+    // Kafka
+    implementation 'org.springframework.kafka:spring-kafka'
 
     // swagger
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.6.0'

--- a/build.gradle
+++ b/build.gradle
@@ -50,6 +50,9 @@ dependencies {
     // Kafka
     implementation 'org.springframework.kafka:spring-kafka'
 
+    // validation
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
+
     // swagger
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.6.0'
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,1 +1,1 @@
-rootProject.name = 'test'
+rootProject.name = 'reward'

--- a/src/main/java/com/mulmeong/event/member/MemberBadgeUpdateEvent.java
+++ b/src/main/java/com/mulmeong/event/member/MemberBadgeUpdateEvent.java
@@ -1,0 +1,31 @@
+package com.mulmeong.event.member;
+
+import com.mulmeong.reward.badge.domain.MemberBadge;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@Builder
+@AllArgsConstructor
+public class MemberBadgeUpdateEvent {
+    private String memberUuid;
+    private Long id;
+    private String name;
+    private String imageUrl;
+    private String description;
+    private boolean equipped;
+
+    public static MemberBadgeUpdateEvent from(MemberBadge memberBadge, boolean equipped) {
+        return MemberBadgeUpdateEvent.builder()
+                .memberUuid(memberBadge.getMemberUuid())
+                .id(memberBadge.getBadge().getId())
+                .name(memberBadge.getBadge().getName())
+                .imageUrl(memberBadge.getBadge().getImageUrl())
+                .description(memberBadge.getBadge().getDescription())
+                .equipped(equipped)
+                .build();
+    }
+}

--- a/src/main/java/com/mulmeong/reward/RewardApplication.java
+++ b/src/main/java/com/mulmeong/reward/RewardApplication.java
@@ -3,7 +3,9 @@ package com.mulmeong.reward;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.cloud.client.discovery.EnableDiscoveryClient;
+import org.springframework.cloud.context.config.annotation.RefreshScope;
 
+@RefreshScope
 @EnableDiscoveryClient
 @SpringBootApplication
 public class RewardApplication {

--- a/src/main/java/com/mulmeong/reward/RewardApplication.java
+++ b/src/main/java/com/mulmeong/reward/RewardApplication.java
@@ -1,4 +1,4 @@
-package com.mulmeong.test;
+package com.mulmeong.reward;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
@@ -6,10 +6,10 @@ import org.springframework.cloud.client.discovery.EnableDiscoveryClient;
 
 @EnableDiscoveryClient
 @SpringBootApplication
-public class TestApplication {
+public class RewardApplication {
 
     public static void main(String[] args) {
-        SpringApplication.run(TestApplication.class, args);
+        SpringApplication.run(RewardApplication.class, args);
     }
 
 }

--- a/src/main/java/com/mulmeong/reward/badge/application/BadgeService.java
+++ b/src/main/java/com/mulmeong/reward/badge/application/BadgeService.java
@@ -1,8 +1,8 @@
 package com.mulmeong.reward.badge.application;
 
-import com.mulmeong.reward.badge.dto.BadgeDto;
 import com.mulmeong.reward.badge.dto.in.BadgeCreateDto;
 import com.mulmeong.reward.badge.dto.in.BadgeUpdateDto;
+import com.mulmeong.reward.badge.dto.out.BadgeDto;
 
 import java.util.List;
 
@@ -10,11 +10,12 @@ public interface BadgeService {
 
     void createBadge(BadgeCreateDto badgeCreateDto);
 
+    void updateBadge(BadgeUpdateDto badgeUpdateDto);
+
+    void deleteBadge(Long badgeId);
+
     BadgeDto getBadge(Long badgeId);
 
     List<BadgeDto> getAllBadges();
 
-    void updateBadge(BadgeUpdateDto badgeUpdateDto);
-
-    void deleteBadge(Long badgeId);
 }

--- a/src/main/java/com/mulmeong/reward/badge/application/BadgeService.java
+++ b/src/main/java/com/mulmeong/reward/badge/application/BadgeService.java
@@ -1,0 +1,20 @@
+package com.mulmeong.reward.badge.application;
+
+import com.mulmeong.reward.badge.dto.BadgeDto;
+import com.mulmeong.reward.badge.dto.in.BadgeCreateDto;
+import com.mulmeong.reward.badge.dto.in.BadgeUpdateDto;
+
+import java.util.List;
+
+public interface BadgeService {
+
+    void createBadge(BadgeCreateDto badgeCreateDto);
+
+    BadgeDto getBadge(Long badgeId);
+
+    List<BadgeDto> getAllBadges();
+
+    void updateBadge(BadgeUpdateDto badgeUpdateDto);
+
+    void deleteBadge(Long badgeId);
+}

--- a/src/main/java/com/mulmeong/reward/badge/application/BadgeServiceImpl.java
+++ b/src/main/java/com/mulmeong/reward/badge/application/BadgeServiceImpl.java
@@ -1,13 +1,13 @@
 package com.mulmeong.reward.badge.application;
 
-import com.mulmeong.reward.badge.dto.BadgeDto;
 import com.mulmeong.reward.badge.dto.in.BadgeCreateDto;
 import com.mulmeong.reward.badge.dto.in.BadgeUpdateDto;
+import com.mulmeong.reward.badge.dto.out.BadgeDto;
 import com.mulmeong.reward.badge.infrastructure.BadgeRepository;
-import com.mulmeong.reward.badge.infrastructure.MemberBadgeRepository;
 import com.mulmeong.reward.common.exception.BaseException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
@@ -19,35 +19,44 @@ import static com.mulmeong.reward.common.response.BaseResponseStatus.NO_BADGE;
 public class BadgeServiceImpl implements BadgeService {
 
     private final BadgeRepository badgeRepository;
-    private final MemberBadgeRepository memberBadgeRepository;
 
-
+    /* (관리자) 뱃지 생성 */
     @Override
+    @Transactional(rollbackFor = Exception.class)
     public void createBadge(BadgeCreateDto requestDto) {
         badgeRepository.save(requestDto.toEntity());
     }
 
+    /* (관리자) 뱃지 수정 */
     @Override
-    public BadgeDto getBadge(Long badgeId) {
-        return BadgeDto.fromEntity(badgeRepository.findById(badgeId)
-                .orElseThrow(() -> new BaseException(NO_BADGE)));
-    }
-
-    @Override
-    public List<BadgeDto> getAllBadges() {
-        return badgeRepository.findAll().stream().map(BadgeDto::fromEntity).toList();
-
-    }
-
-    @Override
+    @Transactional(rollbackFor = Exception.class)
     public void updateBadge(BadgeUpdateDto requestDto) {
         badgeRepository.save(requestDto.toEntity(badgeRepository.findById(requestDto.getId())
                 .orElseThrow(() -> new BaseException(NO_BADGE))));
     }
 
+    /* (관리자) 뱃지 삭제 */
     @Override
+    @Transactional(rollbackFor = Exception.class)
     public void deleteBadge(Long badgeId) {
         badgeRepository.delete(badgeRepository.findById(badgeId)
                 .orElseThrow(() -> new BaseException(NO_BADGE)));
+    }
+
+    /* 뱃지 단건 조회 */
+    @Override
+    @Transactional(readOnly = true)
+    public BadgeDto getBadge(Long badgeId) {
+        return BadgeDto.fromEntity(badgeRepository.findById(badgeId)
+                .orElseThrow(() -> new BaseException(NO_BADGE)));
+    }
+
+    /* 뱃지 전체 조회 */
+    @Override
+    @Transactional(readOnly = true)
+    public List<BadgeDto> getAllBadges() {
+        return badgeRepository.findAll().stream()
+                .map(BadgeDto::fromEntity)
+                .toList();
     }
 }

--- a/src/main/java/com/mulmeong/reward/badge/application/BadgeServiceImpl.java
+++ b/src/main/java/com/mulmeong/reward/badge/application/BadgeServiceImpl.java
@@ -1,0 +1,53 @@
+package com.mulmeong.reward.badge.application;
+
+import com.mulmeong.reward.badge.dto.BadgeDto;
+import com.mulmeong.reward.badge.dto.in.BadgeCreateDto;
+import com.mulmeong.reward.badge.dto.in.BadgeUpdateDto;
+import com.mulmeong.reward.badge.infrastructure.BadgeRepository;
+import com.mulmeong.reward.badge.infrastructure.MemberBadgeRepository;
+import com.mulmeong.reward.common.exception.BaseException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+import static com.mulmeong.reward.common.response.BaseResponseStatus.NO_BADGE;
+
+
+@RequiredArgsConstructor
+@Service
+public class BadgeServiceImpl implements BadgeService {
+
+    private final BadgeRepository badgeRepository;
+    private final MemberBadgeRepository memberBadgeRepository;
+
+
+    @Override
+    public void createBadge(BadgeCreateDto requestDto) {
+        badgeRepository.save(requestDto.toEntity());
+    }
+
+    @Override
+    public BadgeDto getBadge(Long badgeId) {
+        return BadgeDto.fromEntity(badgeRepository.findById(badgeId)
+                .orElseThrow(() -> new BaseException(NO_BADGE)));
+    }
+
+    @Override
+    public List<BadgeDto> getAllBadges() {
+        return badgeRepository.findAll().stream().map(BadgeDto::fromEntity).toList();
+
+    }
+
+    @Override
+    public void updateBadge(BadgeUpdateDto requestDto) {
+        badgeRepository.save(requestDto.toEntity(badgeRepository.findById(requestDto.getId())
+                .orElseThrow(() -> new BaseException(NO_BADGE))));
+    }
+
+    @Override
+    public void deleteBadge(Long badgeId) {
+        badgeRepository.delete(badgeRepository.findById(badgeId)
+                .orElseThrow(() -> new BaseException(NO_BADGE)));
+    }
+}

--- a/src/main/java/com/mulmeong/reward/badge/application/MemberBadgeService.java
+++ b/src/main/java/com/mulmeong/reward/badge/application/MemberBadgeService.java
@@ -1,0 +1,18 @@
+package com.mulmeong.reward.badge.application;
+
+import com.mulmeong.reward.badge.dto.in.MemberBadgeCreateDto;
+import com.mulmeong.reward.badge.dto.in.MemberBadgeUpdateDto;
+import com.mulmeong.reward.badge.dto.out.MemberBadgeDto;
+
+import java.util.List;
+
+public interface MemberBadgeService {
+
+    void createMemberBadge(MemberBadgeCreateDto memberBadgeCreateDto);
+
+    void updateBadgeEquipStatus(MemberBadgeUpdateDto memberBadgeUpdateDto);
+
+    List<MemberBadgeDto> getMemberBadges(String memberUuid);
+
+    MemberBadgeDto getMemberBadge(String memberUuid, Long badgeId);
+}

--- a/src/main/java/com/mulmeong/reward/badge/application/MemberBadgeServiceImpl.java
+++ b/src/main/java/com/mulmeong/reward/badge/application/MemberBadgeServiceImpl.java
@@ -1,12 +1,15 @@
 package com.mulmeong.reward.badge.application;
 
+import com.mulmeong.event.member.MemberBadgeUpdateEvent;
 import com.mulmeong.reward.badge.domain.MemberBadge;
 import com.mulmeong.reward.badge.dto.in.MemberBadgeCreateDto;
 import com.mulmeong.reward.badge.dto.in.MemberBadgeUpdateDto;
 import com.mulmeong.reward.badge.dto.out.MemberBadgeDto;
+import com.mulmeong.reward.badge.infrastructure.BadgeEventPublisher;
 import com.mulmeong.reward.badge.infrastructure.MemberBadgeRepository;
 import com.mulmeong.reward.common.exception.BaseException;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -14,37 +17,41 @@ import java.util.List;
 
 import static com.mulmeong.reward.common.response.BaseResponseStatus.NO_BADGE;
 
+@Slf4j
 @RequiredArgsConstructor
 @Service
 public class MemberBadgeServiceImpl implements MemberBadgeService {
 
     private final MemberBadgeRepository memberBadgeRepository;
 
+    private final BadgeEventPublisher eventPublisher;
+
     /**
      * 회원_뱃지 수정 API(회원이 뱃지 장착/해제)
      * 관련 정책: 회원은 최대 하나의 뱃지를 장착 가능.
      * 요청이 장착인 경우, 기존 장착 뱃지는 해제하고, 요청 뱃지를 장착하며,
-     * 요청이 해제인 경우, 요청 뱃지의 장착을 해제함(장착된 뱃지 X).
+     * 요청이 해제인 경우, 요청 뱃지의 장착 상태를 해제합니다.
+     * 그 후 이벤트를 발행해 ReadDB에 반영합니다.
      *
-     * @param requestDto id, 회원uuid, 뱃지id, 장착 여부
+     * @param requestDto 회원uuid, 뱃지id, 장착 여부
      */
     @Override
     @Transactional(rollbackFor = Exception.class)
     public void updateBadgeEquipStatus(MemberBadgeUpdateDto requestDto) {
 
-        // 요청 뱃지 조회
         String memberUuid = requestDto.getMemberUuid();
-        MemberBadge memberBadge = memberBadgeRepository.findByMemberUuidAndBadgeId(
-                        memberUuid, requestDto.getBadgeId())
-                .orElseThrow(() -> new BaseException(NO_BADGE));
+        boolean isEquipped = requestDto.getEquipped();
 
-        // 장착 요청의 경우, 기존 장착 뱃지 해제(장착 뱃지가 없는 경우는 무시)
-        if (requestDto.getEquipped()) {
-            memberBadgeRepository.findByMemberUuidAndEquipped(memberUuid, true)
-                    .ifPresent(this::updateEquippedStatus);
+        if (isEquipped) {
+            unEquipExistingBadge(memberUuid);
         }
 
-        memberBadgeRepository.save(requestDto.toEntity(memberBadge));
+        MemberBadge memberBadge = memberBadgeRepository.findByMemberUuidAndBadgeId(memberUuid, requestDto.getBadgeId())
+                .orElseThrow(() -> new BaseException(NO_BADGE));
+
+        // 요청대로 뱃지 장착/해제 상태 변경
+        updateEquippedStatus(memberBadge, isEquipped);
+        eventPublisher.send(MemberBadgeUpdateEvent.from(memberBadge, isEquipped));
     }
 
     /**
@@ -75,9 +82,8 @@ public class MemberBadgeServiceImpl implements MemberBadgeService {
     }
 
 
-    // Kafka Event
     /**
-     * 회원_뱃지 추가(회원이 뱃지 수여 조건 충족시 회원에게 뱃지 부여)
+     * 회원_뱃지 추가 API 겸 이벤트 소비자.
      * 1. 특정 Badge관련 Event가 발행되면, 여기서 consume하여 뱃지를 부여.
      * 2. API를 통해 뱃지를 부여할 회원의 uuid와 뱃지의 id를 받아서 뱃지를 부여.
      *
@@ -89,14 +95,21 @@ public class MemberBadgeServiceImpl implements MemberBadgeService {
         memberBadgeRepository.save(requestDto.toEntity());
     }
 
-    /* 회원 뱃지의 장착 상태를 반전 시키는 private 메서드 */
-    private void updateEquippedStatus(MemberBadge memberBadge) {
+    //// private 메서드
 
+    // 이미 장착된 뱃지가 있으면 해제하는 메서드
+    private void unEquipExistingBadge(String memberUuid) {
+        memberBadgeRepository.findByMemberUuidAndEquipped(memberUuid, true)
+                .ifPresent(existingBadge -> updateEquippedStatus(existingBadge, false));
+    }
+
+    // 회원 뱃지의 장착 상태를 수정하는 private 메서드
+    private void updateEquippedStatus(MemberBadge memberBadge, boolean isEquipped) {
         memberBadgeRepository.save(MemberBadge.builder()
                 .id(memberBadge.getId())
                 .memberUuid(memberBadge.getMemberUuid())
-                .badgeId(memberBadge.getBadgeId())
-                .equipped(!memberBadge.getEquipped())
+                .badge(memberBadge.getBadge())
+                .equipped(isEquipped)
                 .build());
     }
 }

--- a/src/main/java/com/mulmeong/reward/badge/application/MemberBadgeServiceImpl.java
+++ b/src/main/java/com/mulmeong/reward/badge/application/MemberBadgeServiceImpl.java
@@ -1,0 +1,102 @@
+package com.mulmeong.reward.badge.application;
+
+import com.mulmeong.reward.badge.domain.MemberBadge;
+import com.mulmeong.reward.badge.dto.in.MemberBadgeCreateDto;
+import com.mulmeong.reward.badge.dto.in.MemberBadgeUpdateDto;
+import com.mulmeong.reward.badge.dto.out.MemberBadgeDto;
+import com.mulmeong.reward.badge.infrastructure.MemberBadgeRepository;
+import com.mulmeong.reward.common.exception.BaseException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+import static com.mulmeong.reward.common.response.BaseResponseStatus.NO_BADGE;
+
+@RequiredArgsConstructor
+@Service
+public class MemberBadgeServiceImpl implements MemberBadgeService {
+
+    private final MemberBadgeRepository memberBadgeRepository;
+
+    /**
+     * 회원_뱃지 수정 API(회원이 뱃지 장착/해제)
+     * 관련 정책: 회원은 최대 하나의 뱃지를 장착 가능.
+     * 요청이 장착인 경우, 기존 장착 뱃지는 해제하고, 요청 뱃지를 장착하며,
+     * 요청이 해제인 경우, 요청 뱃지의 장착을 해제함(장착된 뱃지 X).
+     *
+     * @param requestDto id, 회원uuid, 뱃지id, 장착 여부
+     */
+    @Override
+    @Transactional(rollbackFor = Exception.class)
+    public void updateBadgeEquipStatus(MemberBadgeUpdateDto requestDto) {
+
+        // 요청 뱃지 조회
+        String memberUuid = requestDto.getMemberUuid();
+        MemberBadge memberBadge = memberBadgeRepository.findByMemberUuidAndBadgeId(
+                        memberUuid, requestDto.getBadgeId())
+                .orElseThrow(() -> new BaseException(NO_BADGE));
+
+        // 장착 요청의 경우, 기존 장착 뱃지 해제(장착 뱃지가 없는 경우는 무시)
+        if (requestDto.getEquipped()) {
+            memberBadgeRepository.findByMemberUuidAndEquipped(memberUuid, true)
+                    .ifPresent(this::updateEquippedStatus);
+        }
+
+        memberBadgeRepository.save(requestDto.toEntity(memberBadge));
+    }
+
+    /**
+     * 회원이 가진 특정 뱃지 조회.
+     *
+     * @return 회원이 가진 특정 뱃지(ID, 장착 여부)
+     */
+    @Override
+    @Transactional(readOnly = true)
+    public MemberBadgeDto getMemberBadge(String memberUuid, Long badgeId) {
+
+        return MemberBadgeDto.fromEntity(memberBadgeRepository.findByMemberUuidAndBadgeId(memberUuid, badgeId)
+                .orElseThrow(() -> new BaseException(NO_BADGE)));
+    }
+
+    /**
+     * 회원이 가진 뱃지 목록 조회.
+     *
+     * @return 회원이 가진 뱃지 목록(ID, 장착 여부)
+     */
+    @Override
+    @Transactional(readOnly = true)
+    public List<MemberBadgeDto> getMemberBadges(String memberUuid) {
+
+        return memberBadgeRepository.findAllByMemberUuid(memberUuid).stream()
+                .map(MemberBadgeDto::fromEntity)
+                .toList();
+    }
+
+
+    // Kafka Event
+    /**
+     * 회원_뱃지 추가(회원이 뱃지 수여 조건 충족시 회원에게 뱃지 부여)
+     * 1. 특정 Badge관련 Event가 발행되면, 여기서 consume하여 뱃지를 부여.
+     * 2. API를 통해 뱃지를 부여할 회원의 uuid와 뱃지의 id를 받아서 뱃지를 부여.
+     *
+     * @param requestDto 회원uuid, 뱃지id, 장착 여부(false)
+     */
+    @Override
+    @Transactional(rollbackFor = Exception.class)
+    public void createMemberBadge(MemberBadgeCreateDto requestDto) {
+        memberBadgeRepository.save(requestDto.toEntity());
+    }
+
+    /* 회원 뱃지의 장착 상태를 반전 시키는 private 메서드 */
+    private void updateEquippedStatus(MemberBadge memberBadge) {
+
+        memberBadgeRepository.save(MemberBadge.builder()
+                .id(memberBadge.getId())
+                .memberUuid(memberBadge.getMemberUuid())
+                .badgeId(memberBadge.getBadgeId())
+                .equipped(!memberBadge.getEquipped())
+                .build());
+    }
+}

--- a/src/main/java/com/mulmeong/reward/badge/domain/Badge.java
+++ b/src/main/java/com/mulmeong/reward/badge/domain/Badge.java
@@ -1,0 +1,37 @@
+package com.mulmeong.reward.badge.domain;
+
+import jakarta.persistence.*;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.Comment;
+
+@NoArgsConstructor
+@Getter
+@Entity
+public class Badge {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Comment("뱃지 이름")
+    @Column(nullable = false, length = 20)
+    private String name;
+
+    @Comment("뱃지 이미지 URL")
+    @Column(nullable = false, length = 2083)
+    private String imageUrl;
+
+    @Comment("뱃지 설명")
+    @Column(length = 100)
+    private String description;
+
+    @Builder
+    public Badge(Long id, String name, String imageUrl, String description) {
+        this.id = id;
+        this.name = name;
+        this.imageUrl = imageUrl;
+        this.description = description;
+    }
+}

--- a/src/main/java/com/mulmeong/reward/badge/domain/MemberBadge.java
+++ b/src/main/java/com/mulmeong/reward/badge/domain/MemberBadge.java
@@ -4,8 +4,10 @@ import jakarta.persistence.*;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.ColumnDefault;
 import org.hibernate.annotations.Comment;
 
+@Table(uniqueConstraints = {@UniqueConstraint(columnNames = {"memberUuid", "badgeId"})})
 @NoArgsConstructor
 @Getter
 @Entity
@@ -21,18 +23,19 @@ public class MemberBadge {
 
     @Comment("뱃지 ID")
     @Column(nullable = false)
-    private Integer badgeId;
+    private Long badgeId;
 
     @Comment("착용 여부")
+    @ColumnDefault("false")
     @Column(nullable = false)
-    private boolean isEquipped;
+    private Boolean equipped;
 
     @Builder
-    public MemberBadge(Long id, String memberUuid, Integer badgeId, boolean isEquipped) {
+    public MemberBadge(Long id, String memberUuid, Long badgeId, Boolean equipped) {
         this.id = id;
         this.memberUuid = memberUuid;
         this.badgeId = badgeId;
-        this.isEquipped = isEquipped;
+        this.equipped = equipped;
     }
 }
 

--- a/src/main/java/com/mulmeong/reward/badge/domain/MemberBadge.java
+++ b/src/main/java/com/mulmeong/reward/badge/domain/MemberBadge.java
@@ -22,19 +22,20 @@ public class MemberBadge {
     private String memberUuid;
 
     @Comment("뱃지 ID")
-    @Column(nullable = false)
-    private Long badgeId;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "badge_id")
+    private Badge badge;
 
     @Comment("착용 여부")
-    @ColumnDefault("false")
     @Column(nullable = false)
+    @ColumnDefault("false")
     private Boolean equipped;
 
     @Builder
-    public MemberBadge(Long id, String memberUuid, Long badgeId, Boolean equipped) {
+    public MemberBadge(Long id, String memberUuid, Badge badge, Boolean equipped) {
         this.id = id;
         this.memberUuid = memberUuid;
-        this.badgeId = badgeId;
+        this.badge = badge;
         this.equipped = equipped;
     }
 }

--- a/src/main/java/com/mulmeong/reward/badge/domain/MemberBadge.java
+++ b/src/main/java/com/mulmeong/reward/badge/domain/MemberBadge.java
@@ -1,0 +1,38 @@
+package com.mulmeong.reward.badge.domain;
+
+import jakarta.persistence.*;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.Comment;
+
+@NoArgsConstructor
+@Getter
+@Entity
+public class MemberBadge {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Comment("회원 UUID")
+    @Column(nullable = false, length = 36)
+    private String memberUuid;
+
+    @Comment("뱃지 ID")
+    @Column(nullable = false)
+    private Integer badgeId;
+
+    @Comment("착용 여부")
+    @Column(nullable = false)
+    private boolean isEquipped;
+
+    @Builder
+    public MemberBadge(Long id, String memberUuid, Integer badgeId, boolean isEquipped) {
+        this.id = id;
+        this.memberUuid = memberUuid;
+        this.badgeId = badgeId;
+        this.isEquipped = isEquipped;
+    }
+}
+

--- a/src/main/java/com/mulmeong/reward/badge/dto/BadgeDto.java
+++ b/src/main/java/com/mulmeong/reward/badge/dto/BadgeDto.java
@@ -1,0 +1,28 @@
+package com.mulmeong.reward.badge.dto;
+
+import com.mulmeong.reward.badge.domain.Badge;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class BadgeDto {
+
+    private Long id;
+    private String name;
+    private String imageUrl;
+    private String description;
+
+    public static BadgeDto fromEntity(Badge badge) {
+        return BadgeDto.builder()
+                .id(badge.getId())
+                .name(badge.getName())
+                .imageUrl(badge.getImageUrl())
+                .description(badge.getDescription())
+                .build();
+    }
+
+
+}

--- a/src/main/java/com/mulmeong/reward/badge/dto/in/BadgeCreateDto.java
+++ b/src/main/java/com/mulmeong/reward/badge/dto/in/BadgeCreateDto.java
@@ -1,0 +1,33 @@
+package com.mulmeong.reward.badge.dto.in;
+
+import com.mulmeong.reward.badge.domain.Badge;
+import com.mulmeong.reward.badge.vo.in.BadgeCreateVo;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class BadgeCreateDto {
+
+    private String name;
+    private String imageUrl;
+    private String description;
+
+    public static BadgeCreateDto toDto(BadgeCreateVo vo) {
+        return BadgeCreateDto.builder()
+                .name(vo.getName())
+                .imageUrl(vo.getImageUrl())
+                .description(vo.getDescription())
+                .build();
+    }
+
+    public Badge toEntity() {
+        return Badge.builder()
+                .name(name)
+                .imageUrl(imageUrl)
+                .description(description)
+                .build();
+    }
+}

--- a/src/main/java/com/mulmeong/reward/badge/dto/in/BadgeUpdateDto.java
+++ b/src/main/java/com/mulmeong/reward/badge/dto/in/BadgeUpdateDto.java
@@ -1,0 +1,36 @@
+package com.mulmeong.reward.badge.dto.in;
+
+import com.mulmeong.reward.badge.domain.Badge;
+import com.mulmeong.reward.badge.vo.in.BadgeUpdateVo;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+@Builder
+public class BadgeUpdateDto {
+
+    private Long id;
+    private String name;
+    private String imageUrl;
+    private String description;
+
+    public static BadgeUpdateDto toDto(BadgeUpdateVo vo, Long id) {
+        return BadgeUpdateDto.builder()
+                .id(id)
+                .name(vo.getName())
+                .imageUrl(vo.getImageUrl())
+                .description(vo.getDescription())
+                .build();
+    }
+
+    public Badge toEntity(Badge badge) {
+        return Badge.builder()
+                .id(badge.getId())
+                .name(name)
+                .imageUrl(imageUrl)
+                .description(description)
+                .build();
+    }
+}

--- a/src/main/java/com/mulmeong/reward/badge/dto/in/MemberBadgeCreateDto.java
+++ b/src/main/java/com/mulmeong/reward/badge/dto/in/MemberBadgeCreateDto.java
@@ -1,5 +1,6 @@
 package com.mulmeong.reward.badge.dto.in;
 
+import com.mulmeong.reward.badge.domain.Badge;
 import com.mulmeong.reward.badge.domain.MemberBadge;
 import com.mulmeong.reward.badge.vo.in.BadgeCreateVo;
 import com.mulmeong.reward.badge.vo.in.MemberBadgeCreateVo;
@@ -25,7 +26,7 @@ public class MemberBadgeCreateDto {
     public MemberBadge toEntity() {
         return MemberBadge.builder()
                 .memberUuid(memberUuid)
-                .badgeId(badgeId)
+                .badge(Badge.builder().id(badgeId).build())
                 .equipped(false)
                 .build();
     }

--- a/src/main/java/com/mulmeong/reward/badge/dto/in/MemberBadgeCreateDto.java
+++ b/src/main/java/com/mulmeong/reward/badge/dto/in/MemberBadgeCreateDto.java
@@ -1,0 +1,32 @@
+package com.mulmeong.reward.badge.dto.in;
+
+import com.mulmeong.reward.badge.domain.MemberBadge;
+import com.mulmeong.reward.badge.vo.in.BadgeCreateVo;
+import com.mulmeong.reward.badge.vo.in.MemberBadgeCreateVo;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class MemberBadgeCreateDto {
+
+    private String memberUuid;
+    private Long badgeId;
+
+    public static MemberBadgeCreateDto toDto(MemberBadgeCreateVo vo, String memberUuid) {
+        return MemberBadgeCreateDto.builder()
+                .memberUuid(memberUuid)
+                .badgeId(vo.getBadgeId())
+                .build();
+    }
+
+    public MemberBadge toEntity() {
+        return MemberBadge.builder()
+                .memberUuid(memberUuid)
+                .badgeId(badgeId)
+                .equipped(false)
+                .build();
+    }
+}

--- a/src/main/java/com/mulmeong/reward/badge/dto/in/MemberBadgeUpdateDto.java
+++ b/src/main/java/com/mulmeong/reward/badge/dto/in/MemberBadgeUpdateDto.java
@@ -27,7 +27,7 @@ public class MemberBadgeUpdateDto {
         return MemberBadge.builder()
                 .id(memberBadge.getId())
                 .memberUuid(memberBadge.getMemberUuid())
-                .badgeId(memberBadge.getBadgeId())
+                .badge(memberBadge.getBadge())
                 .equipped(equipped)
                 .build();
     }

--- a/src/main/java/com/mulmeong/reward/badge/dto/in/MemberBadgeUpdateDto.java
+++ b/src/main/java/com/mulmeong/reward/badge/dto/in/MemberBadgeUpdateDto.java
@@ -1,0 +1,34 @@
+package com.mulmeong.reward.badge.dto.in;
+
+import com.mulmeong.reward.badge.domain.MemberBadge;
+import com.mulmeong.reward.badge.vo.in.MemberBadgeUpdateVo;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class MemberBadgeUpdateDto {
+
+    private String memberUuid;
+    private Long badgeId;
+    private Boolean equipped;
+
+    public static MemberBadgeUpdateDto toDto(MemberBadgeUpdateVo vo, String memberUuid, Long badgeId) {
+        return MemberBadgeUpdateDto.builder()
+                .memberUuid(memberUuid)
+                .badgeId(badgeId)
+                .equipped(vo.getEquipped())
+                .build();
+    }
+
+    public MemberBadge toEntity(MemberBadge memberBadge) {
+        return MemberBadge.builder()
+                .id(memberBadge.getId())
+                .memberUuid(memberBadge.getMemberUuid())
+                .badgeId(memberBadge.getBadgeId())
+                .equipped(equipped)
+                .build();
+    }
+}

--- a/src/main/java/com/mulmeong/reward/badge/dto/out/BadgeDto.java
+++ b/src/main/java/com/mulmeong/reward/badge/dto/out/BadgeDto.java
@@ -1,4 +1,4 @@
-package com.mulmeong.reward.badge.dto;
+package com.mulmeong.reward.badge.dto.out;
 
 import com.mulmeong.reward.badge.domain.Badge;
 import lombok.AllArgsConstructor;
@@ -23,6 +23,4 @@ public class BadgeDto {
                 .description(badge.getDescription())
                 .build();
     }
-
-
 }

--- a/src/main/java/com/mulmeong/reward/badge/dto/out/MemberBadgeDto.java
+++ b/src/main/java/com/mulmeong/reward/badge/dto/out/MemberBadgeDto.java
@@ -1,0 +1,22 @@
+package com.mulmeong.reward.badge.dto.out;
+
+import com.mulmeong.reward.badge.domain.MemberBadge;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class MemberBadgeDto {
+
+    private Long badgeId;
+    private Boolean equipped;
+
+    public static MemberBadgeDto fromEntity(MemberBadge memberBadge) {
+        return MemberBadgeDto.builder()
+                .badgeId(memberBadge.getBadgeId())
+                .equipped(memberBadge.getEquipped())
+                .build();
+    }
+}

--- a/src/main/java/com/mulmeong/reward/badge/dto/out/MemberBadgeDto.java
+++ b/src/main/java/com/mulmeong/reward/badge/dto/out/MemberBadgeDto.java
@@ -1,5 +1,6 @@
 package com.mulmeong.reward.badge.dto.out;
 
+import com.mulmeong.reward.badge.domain.Badge;
 import com.mulmeong.reward.badge.domain.MemberBadge;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -15,7 +16,7 @@ public class MemberBadgeDto {
 
     public static MemberBadgeDto fromEntity(MemberBadge memberBadge) {
         return MemberBadgeDto.builder()
-                .badgeId(memberBadge.getBadgeId())
+                .badgeId(memberBadge.getBadge().getId())
                 .equipped(memberBadge.getEquipped())
                 .build();
     }

--- a/src/main/java/com/mulmeong/reward/badge/infrastructure/BadgeEventPublisher.java
+++ b/src/main/java/com/mulmeong/reward/badge/infrastructure/BadgeEventPublisher.java
@@ -1,0 +1,39 @@
+package com.mulmeong.reward.badge.infrastructure;
+
+import com.mulmeong.event.member.MemberBadgeUpdateEvent;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@RequiredArgsConstructor
+@Component
+public class BadgeEventPublisher {
+
+    private final KafkaTemplate<String, Object> kafkaTemplate;
+
+    /**
+     * send({토픽}, {이벤트}) 메서드 하나로 이벤트를 publish 할 수 있지만
+     * 토픽을 지정하는 부분을 서비스의 비즈니스로직에서 분리하는것이 좋다고 판단해
+     * 본 클래스에서 오버로딩하는 구조로 변경하였습니다.
+     *
+     * @author: 주성광
+     */
+
+    @Value("${event.badge.pub.topics.member-badge-update.name}")
+    private String memberBadgeUpdateEventTopic;
+
+
+    public void send(String topic, Object event) {
+        log.info("이벤트 발행, topic: {}", topic);
+        kafkaTemplate.send(topic, event);
+    }
+
+    public void send(MemberBadgeUpdateEvent event) {
+        kafkaTemplate.send(memberBadgeUpdateEventTopic, event);
+    }
+
+
+}

--- a/src/main/java/com/mulmeong/reward/badge/infrastructure/BadgeRepository.java
+++ b/src/main/java/com/mulmeong/reward/badge/infrastructure/BadgeRepository.java
@@ -1,0 +1,8 @@
+package com.mulmeong.reward.badge.infrastructure;
+
+import com.mulmeong.reward.badge.domain.Badge;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface BadgeRepository extends JpaRepository<Badge, Long> {
+
+}

--- a/src/main/java/com/mulmeong/reward/badge/infrastructure/MemberBadgeRepository.java
+++ b/src/main/java/com/mulmeong/reward/badge/infrastructure/MemberBadgeRepository.java
@@ -3,5 +3,14 @@ package com.mulmeong.reward.badge.infrastructure;
 import com.mulmeong.reward.badge.domain.MemberBadge;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+import java.util.Optional;
+
 public interface MemberBadgeRepository extends JpaRepository<MemberBadge, Long> {
+
+    Optional<MemberBadge> findByMemberUuidAndEquipped(String memberUuid, Boolean equipped);
+
+    Optional<MemberBadge> findByMemberUuidAndBadgeId(String memberUuid, Long badgeId);
+
+    List<MemberBadge> findAllByMemberUuid(String memberUuid);
 }

--- a/src/main/java/com/mulmeong/reward/badge/infrastructure/MemberBadgeRepository.java
+++ b/src/main/java/com/mulmeong/reward/badge/infrastructure/MemberBadgeRepository.java
@@ -1,0 +1,7 @@
+package com.mulmeong.reward.badge.infrastructure;
+
+import com.mulmeong.reward.badge.domain.MemberBadge;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MemberBadgeRepository extends JpaRepository<MemberBadge, Long> {
+}

--- a/src/main/java/com/mulmeong/reward/badge/presentation/AdminBadgeController.java
+++ b/src/main/java/com/mulmeong/reward/badge/presentation/AdminBadgeController.java
@@ -1,0 +1,48 @@
+package com.mulmeong.reward.badge.presentation;
+
+import com.mulmeong.reward.badge.application.BadgeService;
+import com.mulmeong.reward.badge.dto.in.BadgeCreateDto;
+import com.mulmeong.reward.badge.dto.in.BadgeUpdateDto;
+import com.mulmeong.reward.badge.vo.in.BadgeCreateVo;
+import com.mulmeong.reward.badge.vo.in.BadgeUpdateVo;
+import com.mulmeong.reward.common.response.BaseResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+/**
+ * 관리자 전용 뱃지 API 컨트롤러, 관리자 권한 필요.
+ * 뱃지 생성, 수정, 삭제.
+ */
+@Tag(name = "뱃지 API", description = "뱃지 API")
+@RequestMapping("/admin/v1/badge")
+@RequiredArgsConstructor
+@RestController
+public class AdminBadgeController {
+
+    private final BadgeService badgeService;
+
+    @Operation(summary = "(관리자) 뱃지 생성", description = "모든 필드는 NotBlank")
+    @PostMapping
+    public BaseResponse<Void> createBadge(@RequestBody @Valid BadgeCreateVo requestVo) {
+        badgeService.createBadge(BadgeCreateDto.toDto(requestVo));
+        return new BaseResponse<>();
+    }
+
+    @Operation(summary = "(관리자) 뱃지 수정", description = "모든 필드는 NotBlank")
+    @PutMapping("/{badgeId}")
+    public BaseResponse<Void> updateBadge(@PathVariable @Valid Long badgeId,
+                                          @RequestBody BadgeUpdateVo requestVo) {
+        badgeService.updateBadge(BadgeUpdateDto.toDto(requestVo, badgeId));
+        return new BaseResponse<>();
+    }
+
+    @Operation(summary = "(관리자) 뱃지 삭제")
+    @DeleteMapping("/{badgeId}")
+    public BaseResponse<Void> deleteBadge(@PathVariable Long badgeId) {
+        badgeService.deleteBadge(badgeId);
+        return new BaseResponse<>();
+    }
+}

--- a/src/main/java/com/mulmeong/reward/badge/presentation/AuthMemberBadgeController.java
+++ b/src/main/java/com/mulmeong/reward/badge/presentation/AuthMemberBadgeController.java
@@ -1,0 +1,63 @@
+package com.mulmeong.reward.badge.presentation;
+
+import com.mulmeong.reward.badge.application.MemberBadgeService;
+import com.mulmeong.reward.badge.dto.in.MemberBadgeCreateDto;
+import com.mulmeong.reward.badge.dto.in.MemberBadgeUpdateDto;
+import com.mulmeong.reward.badge.dto.out.MemberBadgeDto;
+import com.mulmeong.reward.badge.vo.in.MemberBadgeCreateVo;
+import com.mulmeong.reward.badge.vo.in.MemberBadgeUpdateVo;
+import com.mulmeong.reward.common.response.BaseResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@Tag(name = "회원-뱃지 API", description = "회원이 가진 뱃지 관련한 API(회원만 사용가능)")
+@RequestMapping("/auth/v1/members/{memberUuid}/badges")
+@RequiredArgsConstructor
+@RestController
+public class AuthMemberBadgeController {
+
+    private final MemberBadgeService memberBadgeService;
+
+    @Operation(summary = "회원_뱃지 생성", description = """
+            회원이 뱃지를 획득하는 API입니다. 뱃지는 한 회원당 하나씩 가질 수 있으며
+            뱃지는 획득 시 장착되지 않은 상태로 생성됩니다.
+            """)
+    @PostMapping()
+    public BaseResponse<Void> createMemberBadge(@PathVariable String memberUuid,
+                                                @RequestBody MemberBadgeCreateVo requestVo) {
+        memberBadgeService.createMemberBadge(MemberBadgeCreateDto.toDto(requestVo, memberUuid));
+        return new BaseResponse<>();
+    }
+
+    @Operation(summary = "회원_뱃지 수정", description = """
+            회원이 뱃지를 장착/해제하는 API입니다. 회원은 최대 하나의 뱃지를 장착 가능하기 때문에,
+            장착 요청이 들어올 경우(equipped가 true인 경우), 기존 장착 뱃지는 해제되며,
+            장착 요청이 해제인 경우(equipped가 false인 경우), 장착 뱃지가 없는 상태로 변경됩니다.
+            """)
+    @PutMapping("/{badgeId}/equip")
+    public BaseResponse<Void> updateBadgeEquipStatus(@PathVariable String memberUuid,
+                                                     @PathVariable Long badgeId,
+                                                     @RequestBody MemberBadgeUpdateVo requestVo) {
+        memberBadgeService.updateBadgeEquipStatus(
+                MemberBadgeUpdateDto.toDto(requestVo, memberUuid, badgeId));
+        return new BaseResponse<>();
+    }
+
+    @Operation(summary = "특정 회원이 가진 특정 뱃지 조회")
+    @GetMapping("/{badgeId}")
+    public BaseResponse<MemberBadgeDto> getBadge(@PathVariable String memberUuid, @PathVariable Long badgeId) {
+        return new BaseResponse<>(memberBadgeService.getMemberBadge(memberUuid, badgeId));
+    }
+
+    @Operation(summary = "회원이 가진 모든 뱃지 조회")
+    @GetMapping()
+    public BaseResponse<List<MemberBadgeDto>> getAllBadges(@PathVariable String memberUuid) {
+        return new BaseResponse<>(memberBadgeService.getMemberBadges(memberUuid));
+    }
+
+
+}

--- a/src/main/java/com/mulmeong/reward/badge/presentation/AuthMemberBadgeController.java
+++ b/src/main/java/com/mulmeong/reward/badge/presentation/AuthMemberBadgeController.java
@@ -23,7 +23,7 @@ public class AuthMemberBadgeController {
     private final MemberBadgeService memberBadgeService;
 
     @Operation(summary = "회원_뱃지 생성", description = """
-            회원이 뱃지를 획득하는 API입니다. 뱃지는 한 회원당 하나씩 가질 수 있으며
+            회원이 뱃지를 획득하는 API입니다. 뱃지는 한 회원당 하나씩 가질 수 있으며,
             뱃지는 획득 시 장착되지 않은 상태로 생성됩니다.
             """)
     @PostMapping()
@@ -33,7 +33,7 @@ public class AuthMemberBadgeController {
         return new BaseResponse<>();
     }
 
-    @Operation(summary = "회원_뱃지 수정", description = """
+    @Operation(summary = "회원_뱃지 장착 상태 수정", description = """
             회원이 뱃지를 장착/해제하는 API입니다. 회원은 최대 하나의 뱃지를 장착 가능하기 때문에,
             장착 요청이 들어올 경우(equipped가 true인 경우), 기존 장착 뱃지는 해제되며,
             장착 요청이 해제인 경우(equipped가 false인 경우), 장착 뱃지가 없는 상태로 변경됩니다.
@@ -47,13 +47,13 @@ public class AuthMemberBadgeController {
         return new BaseResponse<>();
     }
 
-    @Operation(summary = "특정 회원이 가진 특정 뱃지 조회")
+    @Operation(summary = "특정 회원이 가진 특정 뱃지 조회", description = "특정 회원이 가진 특정 뱃지의 ID, 장착 여부를 조회합니다.")
     @GetMapping("/{badgeId}")
     public BaseResponse<MemberBadgeDto> getBadge(@PathVariable String memberUuid, @PathVariable Long badgeId) {
         return new BaseResponse<>(memberBadgeService.getMemberBadge(memberUuid, badgeId));
     }
 
-    @Operation(summary = "회원이 가진 모든 뱃지 조회")
+    @Operation(summary = "특정 회원이 가진 모든 뱃지 조회", description = "특정 회원이 가진 모든 뱃지의 ID와 장착 여부를 조회합니다.")
     @GetMapping()
     public BaseResponse<List<MemberBadgeDto>> getAllBadges(@PathVariable String memberUuid) {
         return new BaseResponse<>(memberBadgeService.getMemberBadges(memberUuid));

--- a/src/main/java/com/mulmeong/reward/badge/presentation/BadgeController.java
+++ b/src/main/java/com/mulmeong/reward/badge/presentation/BadgeController.java
@@ -1,0 +1,37 @@
+package com.mulmeong.reward.badge.presentation;
+
+import com.mulmeong.reward.badge.application.BadgeService;
+import com.mulmeong.reward.badge.dto.BadgeDto;
+import com.mulmeong.reward.common.response.BaseResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@Tag(name = "뱃지 API", description = "뱃지 API")
+@RequestMapping("/v1/badge")
+@RequiredArgsConstructor
+@RestController
+public class BadgeController {
+
+    private final BadgeService badgeService;
+
+    @Operation(summary = "뱃지 ID로 단건 조회")
+    @GetMapping("/{badgeId}")
+    public BaseResponse<BadgeDto> getBadge(@PathVariable Long badgeId) {
+
+        return new BaseResponse<>(badgeService.getBadge(badgeId));
+    }
+
+    // 뱃지 갯수가 많아지면 페이징 처리 필요
+    @Operation(summary = "모든 뱃지 조회", description = "QUA의 모든 뱃지를 조회하는 페이지에서 사용")
+    @GetMapping
+    public BaseResponse<List<BadgeDto>> getAllBadges() {
+        return new BaseResponse<>(badgeService.getAllBadges());
+    }
+}

--- a/src/main/java/com/mulmeong/reward/badge/presentation/BadgeController.java
+++ b/src/main/java/com/mulmeong/reward/badge/presentation/BadgeController.java
@@ -1,7 +1,7 @@
 package com.mulmeong.reward.badge.presentation;
 
 import com.mulmeong.reward.badge.application.BadgeService;
-import com.mulmeong.reward.badge.dto.BadgeDto;
+import com.mulmeong.reward.badge.dto.out.BadgeDto;
 import com.mulmeong.reward.common.response.BaseResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;

--- a/src/main/java/com/mulmeong/reward/badge/vo/in/BadgeCreateVo.java
+++ b/src/main/java/com/mulmeong/reward/badge/vo/in/BadgeCreateVo.java
@@ -1,0 +1,18 @@
+package com.mulmeong.reward.badge.vo.in;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+
+@Getter
+public class BadgeCreateVo {
+
+    @NotBlank(message = "뱃지 이름은 필수입니다.")
+    private String name;
+
+    @NotBlank(message = "뱃지 이미지 URL은 필수입니다.")
+    private String imageUrl;
+
+    @NotBlank(message = "뱃지 설명은 필수입니다.")
+    private String description;
+
+}

--- a/src/main/java/com/mulmeong/reward/badge/vo/in/BadgeUpdateVo.java
+++ b/src/main/java/com/mulmeong/reward/badge/vo/in/BadgeUpdateVo.java
@@ -1,0 +1,21 @@
+package com.mulmeong.reward.badge.vo.in;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class BadgeUpdateVo {
+
+    @NotBlank(message = "뱃지 이름은 필수입니다.")
+    private String name;
+
+    @NotBlank(message = "뱃지 이미지 URL은 필수입니다.")
+    private String imageUrl;
+
+    @NotBlank(message = "뱃지 설명은 필수입니다.")
+    private String description;
+}

--- a/src/main/java/com/mulmeong/reward/badge/vo/in/MemberBadgeCreateVo.java
+++ b/src/main/java/com/mulmeong/reward/badge/vo/in/MemberBadgeCreateVo.java
@@ -1,0 +1,11 @@
+package com.mulmeong.reward.badge.vo.in;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+
+@Getter
+public class MemberBadgeCreateVo {
+
+    @NotNull(message = "badgeId는 필수값입니다.")
+    private Long badgeId;
+}

--- a/src/main/java/com/mulmeong/reward/badge/vo/in/MemberBadgeUpdateVo.java
+++ b/src/main/java/com/mulmeong/reward/badge/vo/in/MemberBadgeUpdateVo.java
@@ -1,0 +1,9 @@
+package com.mulmeong.reward.badge.vo.in;
+
+import lombok.Getter;
+
+@Getter
+public class MemberBadgeUpdateVo {
+
+    private Boolean equipped;
+}

--- a/src/main/java/com/mulmeong/reward/common/config/KafkaProducerConfig.java
+++ b/src/main/java/com/mulmeong/reward/common/config/KafkaProducerConfig.java
@@ -1,0 +1,39 @@
+package com.mulmeong.reward.common.config;
+
+import lombok.extern.slf4j.Slf4j;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.core.DefaultKafkaProducerFactory;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.core.ProducerFactory;
+import org.springframework.kafka.support.serializer.JsonSerializer;
+
+import java.util.Map;
+
+import static org.springframework.kafka.support.serializer.JsonSerializer.*;
+
+@Slf4j
+@Configuration
+public class KafkaProducerConfig {
+
+    @Value("${spring.kafka.bootstrap-servers}")
+    private String bootstrapServers;
+
+    @Bean
+    public ProducerFactory<String, Object> producerFactory() {
+        return new DefaultKafkaProducerFactory<>(Map.of(
+                ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers,
+                ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class,
+                ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, JsonSerializer.class,
+                ADD_TYPE_INFO_HEADERS, false
+        ));
+    }
+
+    @Bean
+    public KafkaTemplate<String, Object> kafkaTemplate() {
+        return new KafkaTemplate<>(producerFactory());
+    }
+}

--- a/src/main/java/com/mulmeong/reward/common/config/SwaggerConfig.java
+++ b/src/main/java/com/mulmeong/reward/common/config/SwaggerConfig.java
@@ -1,4 +1,4 @@
-package com.mulmeong.test.common.config;
+package com.mulmeong.reward.common.config;
 
 import io.swagger.v3.oas.annotations.OpenAPIDefinition;
 import io.swagger.v3.oas.annotations.info.Info;
@@ -12,10 +12,9 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 @OpenAPIDefinition(
-        info = @Info(title = "ㅇㅇ 도메인 API", version = "v1",
-                description = " {ㅇㅇ 도메인의 기능 나열} 서비스",
+        info = @Info(title = "리워드 서비스", version = "v1",
+                description = " 포인트, 등급, 뱃지 관련 서비스",
                 termsOfService = "http://swagger.io/terms/")
-
 )
 @Configuration
 @RequiredArgsConstructor
@@ -40,7 +39,7 @@ public class SwaggerConfig {
                 .addSecurityItem(securityRequirement)
                 .components(components)
                 // Swagger에서 요청보낼때 API에 추가되는 문자열
-                .addServersItem(new Server().url("/ㅇㅇ-service"));
+                .addServersItem(new Server().url("/reward-service"));
         //.addServersItem(new Server().url("/"));
     }
 

--- a/src/main/java/com/mulmeong/reward/common/exception/BaseException.java
+++ b/src/main/java/com/mulmeong/reward/common/exception/BaseException.java
@@ -1,6 +1,6 @@
-package com.mulmeong.test.common.exception;
+package com.mulmeong.reward.common.exception;
 
-import com.mulmeong.test.common.response.BaseResponseStatus;
+import com.mulmeong.reward.common.response.BaseResponseStatus;
 import lombok.Getter;
 
 @Getter

--- a/src/main/java/com/mulmeong/reward/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/mulmeong/reward/common/exception/GlobalExceptionHandler.java
@@ -1,13 +1,13 @@
-package com.mulmeong.test.common.exception;
+package com.mulmeong.reward.common.exception;
 
-import com.mulmeong.test.common.response.BaseResponse;
+import com.mulmeong.reward.common.response.BaseResponse;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
-import static com.mulmeong.test.common.response.BaseResponseStatus.INTERNAL_SERVER_ERROR;
-import static com.mulmeong.test.common.response.BaseResponseStatus.INVALID_INPUT_VALUE;
+import static com.mulmeong.reward.common.response.BaseResponseStatus.INTERNAL_SERVER_ERROR;
+import static com.mulmeong.reward.common.response.BaseResponseStatus.INVALID_INPUT_VALUE;
 
 @Slf4j
 @RestControllerAdvice

--- a/src/main/java/com/mulmeong/reward/common/healthcheck/healthcheck/HealthCheckController.java
+++ b/src/main/java/com/mulmeong/reward/common/healthcheck/healthcheck/HealthCheckController.java
@@ -1,11 +1,6 @@
-package com.mulmeong.test.common.healthcheck.healthcheck;
+package com.mulmeong.reward.common.healthcheck.healthcheck;
 
 import io.swagger.v3.oas.annotations.Hidden;
-import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.responses.ApiResponse;
-import io.swagger.v3.oas.annotations.tags.Tag;
-import lombok.RequiredArgsConstructor;
-import org.springframework.core.env.Environment;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;

--- a/src/main/java/com/mulmeong/reward/common/response/BaseResponse.java
+++ b/src/main/java/com/mulmeong/reward/common/response/BaseResponse.java
@@ -1,9 +1,9 @@
-package com.mulmeong.test.common.response;
+package com.mulmeong.reward.common.response;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.http.HttpStatusCode;
 
-import static com.mulmeong.test.common.response.BaseResponseStatus.SUCCESS;
+import static com.mulmeong.reward.common.response.BaseResponseStatus.SUCCESS;
 
 public record BaseResponse<T>(HttpStatusCode httpStatus, Boolean isSuccess, String message, int code, T result) {
 
@@ -31,7 +31,7 @@ public record BaseResponse<T>(HttpStatusCode httpStatus, Boolean isSuccess, Stri
      * @param status 요청 상태
      */
     public BaseResponse(BaseResponseStatus status) {
-        this(status.getHttpStatusCode(), false, status.getMessage(), status.getCode(), null);
+        this(status.getHttpStatusCode(), false, status.getMessage(), status.getCode(), (T) status.getMessage());
     }
 
     /**

--- a/src/main/java/com/mulmeong/reward/common/response/BaseResponseStatus.java
+++ b/src/main/java/com/mulmeong/reward/common/response/BaseResponseStatus.java
@@ -1,4 +1,4 @@
-package com.mulmeong.test.common.response;
+package com.mulmeong.reward.common.response;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;

--- a/src/main/java/com/mulmeong/reward/common/response/BaseResponseStatus.java
+++ b/src/main/java/com/mulmeong/reward/common/response/BaseResponseStatus.java
@@ -22,12 +22,20 @@ public enum BaseResponseStatus {
     NO_SIGN_IN(HttpStatus.UNAUTHORIZED, false, 402, "로그인을 먼저 진행해주세요"),
 
     // 900 : 기타 에러
-    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, false, 900, "요청 처리 중 에러가 발생하였습니다.");
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, false, 900, "요청 처리 중 에러가 발생하였습니다."),
 
+    // 1700 : 뱃지 관련 에러
+    NO_BADGE(HttpStatus.BAD_REQUEST, false, 1700, "존재하지 않는 뱃지입니다."),
+    EXIST_BADGE(HttpStatus.BAD_REQUEST, false, 1701, "이미 존재하는 뱃지입니다.");
+
+    // 1800 : 포인트 관련 에러
+
+    // 1900 : 등급 관련 에러
 
     private final HttpStatusCode httpStatusCode;
     private final boolean isSuccess;
     private final int code;
     private final String message;
+
 }
 

--- a/src/test/java/com/mulmeong/reward/TestApplicationTests.java
+++ b/src/test/java/com/mulmeong/reward/TestApplicationTests.java
@@ -1,7 +1,6 @@
-package com.mulmeong.test;
+package com.mulmeong.reward;
 
 import org.junit.jupiter.api.Test;
-import org.springframework.boot.test.context.SpringBootTest;
 
 //@SpringBootTest
 class TestApplicationTests {


### PR DESCRIPTION

### 📅 2024.11.26~2024.11.28

### 🌵 Branch
feature/badge/2 → develop

### 📢 Description

#### API 9개
- 뱃지 CRUD 코드 작성(R: 단건 조회, 전체 조회)
- 회원 장착 뱃지 생성((회원에게 뱃지를 수여) API
- 회원 뱃지 장착 상태 수정 API + 이벤트 Publish => ReadDB 에서 장착 뱃지 조회하도록 Consume
- 회원 장착 뱃지 Read API(단건, 전체)

### 💬 Issue Number
- #5 
- #6

### ✔️ PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 코드가 정상적으로 동작하는지 테스트 했습니다.

### 🔖 Note
1. 특정 회원에게 Badge를 부여하는 Event Consume은 정책 미비로 아직 구현하지 못했습니다.
2. API 명세된 바 없어 직접 설계하였습니다. API 정의서도 한번 봐주시고 의견 내주시면 감사하겠습니다.